### PR TITLE
Fix to multiple bg music, quits from game screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,6 +192,7 @@ def gameLoop(speed):
                     showPauseScreen()
 
             if event.type == QUIT:
+                pygame.quit()
                 sys.exit()
 
             # check mouse click events
@@ -258,11 +259,9 @@ def gameLoop(speed):
         # Update round points
         if score1 == const.SCORELIMIT:
             rounds_p1 += 1
-            pygame.mixer.Sound.play(backgroundMusic, -1)
             score1, score2 = 0, 0
         if score2 == const.SCORELIMIT:
             rounds_p2 += 1
-            pygame.mixer.Sound.play(backgroundMusic, -1)
             score1, score2 = 0, 0
 
         # playing area should be drawn first


### PR DESCRIPTION
Fixed: The background music doesn't play multiple rimes after rounds now.

Added: Game can be quit from the screen now using its close button.